### PR TITLE
fix: parse new anime stream url and fix command line args

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shadler"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 
 [dependencies]

--- a/shadler.rs
+++ b/shadler.rs
@@ -165,7 +165,7 @@ fn shadler_anime(stream_content: utils::structs::StreamContent) {
         video_source.push_str(
             &matched
             .replace("clock", "clock.json")
-            .replace("/download", "")
+            .replace("/dr", "")
         );
 
         let vid_source_response = utils::api::shadler_get_api_response(&video_source);
@@ -312,7 +312,7 @@ pub fn shadler_is_option(arg: &str) -> bool {
 
 fn main() {
 
-    let mut command_args = std::env::args_os();
+    let mut command_args = std::env::args_os().peekable();
     let subcommand_arg = command_args.nth(1);
 
     let mut query = String::new();
@@ -323,6 +323,7 @@ fn main() {
     while let Some(x) = command_args.next() {
 
         let option = x.into_string().unwrap();
+        println!("{}", option);
 
         if option == "-q" || option == "--query"{
             let temp = command_args
@@ -356,14 +357,18 @@ fn main() {
         } else if option == "-r" || option == "--range" {
 
             let range_lower = command_args
-                .next()
-                .unwrap_or("0".into())
+                .peek()
+                .unwrap()
+                .to_owned()
                 .into_string()
                 .unwrap();
+
+            println!("{}, r_low", range_lower);
 
             if !shadler_is_option(&range_lower) && range_lower != "0" {
                 if let Some(val) = range_lower.parse::<i32>().ok() {
                     range.push(val);
+                    command_args.next();
 
                 }
 
@@ -373,10 +378,13 @@ fn main() {
             }
 
             let range_upper = command_args
-                .next()
-                .unwrap_or("0".into())
+                .peek()
+                .unwrap()
+                .to_owned()
                 .into_string()
                 .unwrap();
+
+            println!("{}, r_high", range_upper);
 
             if !shadler_is_option(&range_upper) && range_upper != "0" {
                 if let Some(val) = range_upper.parse::<i32>().ok() {

--- a/shadler.rs
+++ b/shadler.rs
@@ -323,7 +323,6 @@ fn main() {
     while let Some(x) = command_args.next() {
 
         let option = x.into_string().unwrap();
-        println!("{}", option);
 
         if option == "-q" || option == "--query"{
             let temp = command_args
@@ -363,8 +362,6 @@ fn main() {
                 .into_string()
                 .unwrap();
 
-            println!("{}, r_low", range_lower);
-
             if !shadler_is_option(&range_lower) && range_lower != "0" {
                 if let Some(val) = range_lower.parse::<i32>().ok() {
                     range.push(val);
@@ -383,8 +380,6 @@ fn main() {
                 .to_owned()
                 .into_string()
                 .unwrap();
-
-            println!("{}, r_high", range_upper);
 
             if !shadler_is_option(&range_upper) && range_upper != "0" {
                 if let Some(val) = range_upper.parse::<i32>().ok() {


### PR DESCRIPTION
This fixes a problem where the program is not able to retrieve the stream URL because of API changes, and fix a bug where if you pass the `-q` option right after the `-r` option, the query will not be passed, resulting in having to type the query on the prompt again.