### PR TITLE
fix: remove random exclamation mark and fix termux reader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,7 +287,7 @@ dependencies = [
 
 [[package]]
 name = "shadler"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "regex",
  "serde_json",

--- a/shadler.rs
+++ b/shadler.rs
@@ -1,4 +1,5 @@
-use std::{process::exit, io::Write};
+use std::{fs, process::exit, io::Write};
+use std::os::unix::fs::PermissionsExt;
 use regex::Regex;
 use serde_json::Value;
 use utils::constants::{MAGENTA, BLUE, RED, RESET, YELLOW, GREEN};
@@ -224,7 +225,7 @@ fn shadler_manga(stream_content: utils::structs::StreamContent) {
     // reverse because API returns episodes in descending order instead of ascending
     available_chapters_rev.reverse();
 
-    let chapters_file_info = utils::helper::shadler_create_file("mangas", &selected_turtle, &format!("chp{chapter_start}-{chapter_end}.html"));
+    let chapters_file_info = utils::helper::shadler_create_file("mangas", &selected_turtle, &format!("{chapter_start}-{chapter_end}.html"));
     let chapters_file_path = chapters_file_info.1;
     let mut chapters_file = chapters_file_info.0;
     let mut page_collection = String::new();
@@ -288,6 +289,7 @@ fn shadler_manga(stream_content: utils::structs::StreamContent) {
             .replace("#CHAPTER_STOP#", &format!("{chapter_end}"));
 
         termux_reader_file.write_all(termux_http_server.as_bytes()).unwrap();
+        fs::set_permissions(&termux_reader_file_path, fs::Permissions::from_mode(0o755)).unwrap();
 
         println!("\n{GREEN}HTML file generated. Start reading by running {YELLOW}'{termux_reader_file_path}'{RESET}");
 

--- a/utils/constants.rs
+++ b/utils/constants.rs
@@ -20,7 +20,7 @@ pub static MANGA_READ_HASH: &'static str = "4a048654fbac31f11e201ac8bd34d748b514
 pub static DETAIL_VARS: &'static str = "{%22_id%22:%22#ID#%22}";
 pub static API_EXT: &'static str = "{%22persistedQuery%22:{%22version%22:1,%22sha256Hash%22:%22#HASH#%22}}";
 
-pub static MANGA_READER_BASE: &'static str = "!<DOCTYPE html>
+pub static MANGA_READER_BASE: &'static str = "<!DOCTYPE html>
 <html>
 
     <head>
@@ -38,6 +38,8 @@ pub static MANGA_READER_BASE: &'static str = "!<DOCTYPE html>
 ";
 
 pub static TERMUX_HTTP_SERVER_BASE: &'static str = "#!/bin/sh
+kill -15 \"$(cat /data/data/com.termux/files/usr/tmp/shadler_eerver_lock 2> /dev/null)\" 2> /dev/null
 python3 -m http.server -d '#MANGA_PATH#' 10100 > /dev/null 2>&1 &
+echo \"$!\" > /data/data/com.termux/files/usr/tmp/shadler_server_lock
 termux-open http://127.0.0.1:10100/#CHAPTER_START#-#CHAPTER_STOP#.html
 ";


### PR DESCRIPTION
This fixes several issues including:
- The reader script failed to open the HTML file because file naming mismatch
- The reader script failed to execute due to permission issue
- Lastly, the reader script failed to start HTTP server because another HTTP server has been started by another reader script