### PR TITLE
drop: remove read online and fix manga page downloader

### DIFF
--- a/shadler.rs
+++ b/shadler.rs
@@ -247,24 +247,19 @@ fn shadler_manga(stream_content: utils::structs::StreamContent) {
             let page_path = current_page["url"].as_str().unwrap();
             let page_url = page_url_head.to_owned() + page_path;
 
-            if action == 1 {
-                let page_img_tag = format!("<img src='{page_url}' alt='Failed to load image'>\n");
+            page_counter += 1;
+            let download_result = utils::downloader::shadler_download_file("mangas", &page_url, &selected_turtle, &format!("chp{x}_{page_counter}.png"));
+
+            if let Err(e) = download_result {
+               eprintln!("\n{RED}{e}{RESET}");
+               exit(1);
+
+            } else if let Ok(path) = download_result {
+                let page_img_tag = format!("<img src='{path}' alt='Failed to load image'>\n");
                 page_collection.push_str(&page_img_tag);
 
-            } else if action == 2 {
-                page_counter += 1;
-                let download_result = utils::downloader::shadler_download_file("mangas", &page_url, &selected_turtle, &format!("chp{x}_{page_counter}"));
-
-                if let Err(e) = download_result {
-                    eprintln!("\n{RED}{e}{RESET}");
-                    exit(1);
-
-                } else if let Ok(path) = download_result {
-                    let page_img_tag = format!("<img src='{path}' alt='Failed to load image'>\n");
-                    page_collection.push_str(&page_img_tag);
-
-                }
             }
+
         }
     }
 

--- a/utils/downloader.rs
+++ b/utils/downloader.rs
@@ -9,6 +9,7 @@ pub fn shadler_download_file(content_type: &str, content_link: &str, title: &str
     let mut episode_file = episode_file_info.0;
 
     let response = ureq::head(content_link)
+        .header("Referer", "https://allmanga.to/")
         .call()
         .unwrap();
 
@@ -34,6 +35,7 @@ pub fn shadler_download_file(content_type: &str, content_link: &str, title: &str
 
         let mut video_response = ureq::get(content_link)
         .header("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/112.0")
+        .header("Referer", "https://allmanga.to/")
         .header("Range", &format!("bytes={downloaded_bytes}-{next_chunk}"))
         .call()
         .unwrap();


### PR DESCRIPTION
This fixes the problem where the program failed to download images because its missing the `Referer` header. This PR also removes manga read online feature because of the Referer requirement for requesting images, as it requires the page to be referred by the main site. I will try to find some workaround, but one thing for sure is that Python is very likely to be the next requirement in the future.